### PR TITLE
Fix incorrect icon alias

### DIFF
--- a/app/(tabs)/artists/[name].tsx
+++ b/app/(tabs)/artists/[name].tsx
@@ -19,7 +19,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import {
   ChevronLeft,
   ChevronRight,
-  MoveHorizontal as MoreHorizontal,
+  MoreHorizontal,
   Play,
 } from 'lucide-react-native';
 import DefaultAlbumCover from '@/components/DefaultAlbumCover';

--- a/app/(tabs)/artists/album/[artist]/[name].tsx
+++ b/app/(tabs)/artists/album/[artist]/[name].tsx
@@ -19,7 +19,7 @@ import { BlurView } from 'expo-blur';
 import Colors from '@/constants/Colors';
 import { usePlaybackStatus } from '@/hooks/usePlaybackStatus';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ChevronLeft, Play, MoveHorizontal as MoreHorizontal } from 'lucide-react-native';
+import { ChevronLeft, Play, MoreHorizontal } from 'lucide-react-native';
 import SongItem from '@/components/SongItem';
 import DefaultAlbumCover from '@/components/DefaultAlbumCover';
 

--- a/components/SongItem.tsx
+++ b/components/SongItem.tsx
@@ -4,7 +4,7 @@ import { Track } from '@/context/MusicContext';
 import Colors from '@/constants/Colors';
 import DefaultAlbumCover from './DefaultAlbumCover';
 import { usePlaylists, Playlist } from '@/hooks/usePlaylists';
-import { MoveHorizontal as MoreHorizontal, Play, Share2, Info, Trash2 } from 'lucide-react-native';
+import { MoreHorizontal, Play, Share2, Info, Trash2 } from 'lucide-react-native';
 import { usePlaybackStatus } from '@/hooks/usePlaybackStatus';
 import EditSongScreen from './EditSongScreen';
 import * as Sharing from 'expo-sharing';


### PR DESCRIPTION
## Summary
- use `MoreHorizontal` icon instead of mistakenly aliased `MoveHorizontal`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b1742354832980fd08bdd47ba8af