### PR TITLE
Fix hero banners ignoring safe area

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -11,7 +11,7 @@ export default function TabLayout() {
   
   return (
     <View style={styles.container}>
-      <SafeAreaView style={styles.safeArea} edges={['top']}>
+      <SafeAreaView style={styles.safeArea} edges={[]}>
         <Tabs
           screenOptions={{
             tabBarActiveTintColor: Colors.tint,

--- a/app/(tabs)/artists/index.tsx
+++ b/app/(tabs)/artists/index.tsx
@@ -77,7 +77,7 @@ export default function ArtistsScreen() {
   );
 
   return (
-    <SafeAreaView edges={['bottom']} style={styles.container}>
+    <SafeAreaView edges={['top', 'bottom']} style={styles.container}>
       <View style={styles.content}>
         <Text style={styles.title}>Artists</Text>
         

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -43,7 +43,7 @@ export default function LibraryScreen() {
   }
 
   return (
-    <SafeAreaView edges={['bottom']} style={styles.container}>
+    <SafeAreaView edges={['top', 'bottom']} style={styles.container}>
       <View style={styles.content}>
         <Text style={styles.title}>Library</Text>
         <View style={styles.headerContainer}>

--- a/app/(tabs)/playlists.tsx
+++ b/app/(tabs)/playlists.tsx
@@ -65,7 +65,7 @@ export default function PlaylistsScreen() {
   );
 
   return (
-    <SafeAreaView edges={['bottom']} style={styles.container}>
+    <SafeAreaView edges={['top', 'bottom']} style={styles.container}>
       <View style={styles.content}>
         <Text style={styles.title}>Playlists</Text>
         


### PR DESCRIPTION
## Summary
- allow hero banners on artist and album screens to extend under the status bar
- update screens that relied on the previous top safe area handling

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a25e4f3c83298cd6f2cddcdbd0a3