### PR TITLE
Fix incorrect icon alias

### DIFF
--- a/app/(tabs)/artists/[name].tsx
+++ b/app/(tabs)/artists/[name].tsx
@@ -19,18 +19,19 @@ import { router, useLocalSearchParams } from 'expo-router';
 import {
   ChevronLeft,
   ChevronRight,
-  MoveHorizontal as MoreHorizontal,
+  MoreHorizontal,
   Play,
 } from 'lucide-react-native';
 import DefaultAlbumCover from '@/components/DefaultAlbumCover';
 import { ArtworkBanner } from '@/components/ArtworkBanner';
+
+const HEADER_HEIGHT = 60;
 
 export default function ArtistScreen() {
   const { name } = useLocalSearchParams<{ name: string }>();
   const { tracks, playTrack } = usePlaybackStatus();
   const insets = useSafeAreaInsets();
 
-  const HEADER_HEIGHT = 60;
   const [showArtistNameInHeader, setShowArtistNameInHeader] = useState(false);
   const [artistHeaderHeight, setArtistHeaderHeight] = useState(0);
 
@@ -216,7 +217,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingHorizontal: 16,
-    height: 60, // HEADER_HEIGHT
+    height: HEADER_HEIGHT,
   },
   blurCircle: {
     width: 32,

--- a/app/(tabs)/artists/album/[artist]/[name].tsx
+++ b/app/(tabs)/artists/album/[artist]/[name].tsx
@@ -19,9 +19,11 @@ import { BlurView } from 'expo-blur';
 import Colors from '@/constants/Colors';
 import { usePlaybackStatus } from '@/hooks/usePlaybackStatus';
 import { router, useLocalSearchParams } from 'expo-router';
-import { ChevronLeft, Play, MoveHorizontal as MoreHorizontal } from 'lucide-react-native';
+import { ChevronLeft, Play, MoreHorizontal } from 'lucide-react-native';
 import SongItem from '@/components/SongItem';
 import DefaultAlbumCover from '@/components/DefaultAlbumCover';
+
+const HEADER_HEIGHT = 60;
 
 type AlbumBannerProps = {
   artworkUrl: string | null | undefined;
@@ -92,7 +94,6 @@ export default function AlbumScreen() {
   const { tracks, currentTrack, playTrack } = usePlaybackStatus();
 
   const insets = useSafeAreaInsets();
-  const HEADER_HEIGHT = 60;
 
   const [albumHeaderHeight, setAlbumHeaderHeight] = useState(0);
   const [showAlbumNameInHeader, setShowAlbumNameInHeader] = useState(false);
@@ -245,7 +246,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingHorizontal: 16,
-    height: 60,
+    height: HEADER_HEIGHT,
   },
   blurCircle: {
     width: 32,

--- a/components/SongItem.tsx
+++ b/components/SongItem.tsx
@@ -4,7 +4,7 @@ import { Track } from '@/context/MusicContext';
 import Colors from '@/constants/Colors';
 import DefaultAlbumCover from './DefaultAlbumCover';
 import { usePlaylists, Playlist } from '@/hooks/usePlaylists';
-import { MoveHorizontal as MoreHorizontal, Play, Share2, Info, Trash2 } from 'lucide-react-native';
+import { MoreHorizontal, Play, Share2, Info, Trash2 } from 'lucide-react-native';
 import { usePlaybackStatus } from '@/hooks/usePlaybackStatus';
 import EditSongScreen from './EditSongScreen';
 import * as Sharing from 'expo-sharing';


### PR DESCRIPTION
## Summary
- use `MoreHorizontal` icon instead of mistakenly aliased `MoveHorizontal`
- hoist header height constants out of components

## Testing
- `npm run lint` *(fails with React hook errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844b1742354832980fd08bdd47ba8af